### PR TITLE
value_from_object: Don't dump by default

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -104,10 +104,10 @@ class JSONFieldBase(six.with_metaclass(SubfieldBase, models.Field)):
         return json.dumps(value, **self.dump_kwargs)
 
     def value_to_string(self, obj):
-        value = self.value_from_object(obj, dump=False)
+        value = self.value_from_object(obj)
         return self.get_db_prep_value(value, None)
 
-    def value_from_object(self, obj, dump=True):
+    def value_from_object(self, obj, dump=False):
         value = super(JSONFieldBase, self).value_from_object(obj)
         if self.null and value is None:
             return None

--- a/jsonfield/tests.py
+++ b/jsonfield/tests.py
@@ -273,6 +273,12 @@ class JSONFieldTest(TestCase):
         model1.save()
         self.assertEqual(model1.empty_default, {"hey": "now"})
 
+    def test_model_to_dict(self):
+        """Test Django model_to_dict returns data instead of string"""
+        instance = self.json_model.objects.create(json={1: 2})
+        as_dict = forms.model_to_dict(instance)
+        self.assertEqual(as_dict['json'], {1: 2})
+
 
 class JSONCharFieldTest(JSONFieldTest):
     json_model = JsonCharModel


### PR DESCRIPTION
Because django.forms.model_to_dict expects it to return value unchanged.